### PR TITLE
Upgrade Selenium, chromedriver and IEDriverServer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: java
 sudo: false
 jdk:
   - oraclejdk7
+  - oraclejdk8
   - openjdk7
 script:
   - sh -e utilities/run-travis-ci-tests.sh

--- a/archetype/src/main/resources/archetype-resources/pom.xml
+++ b/archetype/src/main/resources/archetype-resources/pom.xml
@@ -30,7 +30,7 @@
         <dependency>
             <groupId>org.seleniumhq.selenium</groupId>
             <artifactId>selenium-server</artifactId>
-            <version>2.47.1</version>
+            <version>2.48.2</version>
         </dependency>
     </dependencies>
 

--- a/archetype/src/main/resources/archetype-resources/src/main/java/utilities/server/TestServerUtils.java
+++ b/archetype/src/main/resources/archetype-resources/src/main/java/utilities/server/TestServerUtils.java
@@ -1,5 +1,5 @@
 /*-------------------------------------------------------------------------------------------------------------------*\
-|  Copyright (C) 2014 PayPal                                                                                          |
+|  Copyright (C) 2014-2015 PayPal                                                                                     |
 |                                                                                                                     |
 |  Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance     |
 |  with the License.                                                                                                  |
@@ -15,8 +15,8 @@
 
 package ${package}.utilities.server;
 
-import org.seleniumhq.jetty7.server.Server;
-import org.seleniumhq.jetty7.server.handler.ResourceHandler;
+import org.seleniumhq.jetty9.server.Server;
+import org.seleniumhq.jetty9.server.handler.ResourceHandler;
 import org.openqa.selenium.net.NetworkUtils;
 import org.openqa.selenium.net.PortProber;
 

--- a/client/src/test/java/com/paypal/selion/TestServerUtils.java
+++ b/client/src/test/java/com/paypal/selion/TestServerUtils.java
@@ -17,8 +17,8 @@ package com.paypal.selion;
 
 import org.openqa.selenium.net.NetworkUtils;
 import org.openqa.selenium.net.PortProber;
-import org.seleniumhq.jetty7.server.Server;
-import org.seleniumhq.jetty7.server.handler.ResourceHandler;
+import org.seleniumhq.jetty9.server.Server;
+import org.seleniumhq.jetty9.server.handler.ResourceHandler;
 
 import com.paypal.selion.configuration.Config;
 import com.paypal.selion.configuration.Config.ConfigProperty;

--- a/client/src/test/resources/suites/Full-Suite.xml
+++ b/client/src/test/resources/suites/Full-Suite.xml
@@ -14,7 +14,6 @@
         <suite-file path="SeLionConfig-Suite.xml"></suite-file>
         <suite-file path="SeLionConfig-Parallel-Tests-Suite.xml"></suite-file>
         <suite-file path="SeLionConfig-Parallel-Classes-Suite.xml"></suite-file>
-        <suite-file path="Local-Grid-Tests.xml"></suite-file>
         <suite-file path="Firefox-Suite.xml"></suite-file>
         <suite-file path="Chrome-Suite.xml"></suite-file>
         <suite-file path="IE-Suite.xml"></suite-file>

--- a/client/src/test/resources/suites/Local-Grid-Tests.xml
+++ b/client/src/test/resources/suites/Local-Grid-Tests.xml
@@ -9,7 +9,7 @@
             </run>
         </groups>
         <classes>
-            <class name="com.paypal.selion.platform.grid.LocalGridManagerTest" />
+            <class name="com.paypal.selion.internal.platform.grid.LocalGridManagerTest" />
         </classes>
     </test>
 

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
         <compileSource>1.7</compileSource>
         <skipTests>false</skipTests>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-        <selenium.version>2.47.1</selenium.version>
+        <selenium.version>2.48.2</selenium.version>
         <iosdriver.version>0.6.5</iosdriver.version>
         <selendroid.version>0.17.0</selendroid.version>
         <appium.version>3.1.0</appium.version>

--- a/project-bom/pom.xml
+++ b/project-bom/pom.xml
@@ -154,6 +154,12 @@
                 <groupId>org.seleniumhq.selenium</groupId>
                 <artifactId>selenium-server</artifactId>
                 <version>${selenium.version}</version>
+                <exclusions>
+                    <exclusion>
+                        <groupId>org.mortbay.jetty</groupId>
+                        <artifactId>servlet-api-2.5</artifactId>
+                    </exclusion>
+                </exclusions>
             </dependency>
 
             <dependency>

--- a/server/src/main/resources/config/download.json
+++ b/server/src/main/resources/config/download.json
@@ -3,24 +3,24 @@
     "name": "selenium",
     "roles": [ "node", "hub", "standalone", "sauce" ],
     "any": {
-      "url": "https://selenium-release.storage.googleapis.com/2.47/selenium-server-standalone-2.47.1.jar",
-      "checksum": "e6cb10b8f0f353c6ca4a8f62fb5cb472"
+      "url": "https://selenium-release.storage.googleapis.com/2.48/selenium-server-standalone-2.48.2.jar",
+      "checksum": "b2784fc67c149d3c13c83d2108104689"
     }
   },
   {
     "name": "chromedriver",
     "roles": [ "node", "standalone" ],
     "windows": {
-      "url": "https://chromedriver.storage.googleapis.com/2.16/chromedriver_win32.zip",
-      "checksum": "3e1b4a91e12a9872a4ed83c9e61c122e"
+      "url": "https://chromedriver.storage.googleapis.com/2.20/chromedriver_win32.zip",
+      "checksum": "028ee452b8e23890ec5ec6b0717fd295"
     },
     "linux": {
-      "url": "https://chromedriver.storage.googleapis.com/2.16/chromedriver_linux64.zip",
-      "checksum": "fa8e1bc6f9ce474582876653604d675e"
+      "url": "https://chromedriver.storage.googleapis.com/2.20/chromedriver_linux64.zip",
+      "checksum": "245858cc984bd946df6a1e6719c8e6f5"
     },
     "mac": {
-      "url": "https://chromedriver.storage.googleapis.com/2.16/chromedriver_mac32.zip",
-      "checksum": "3ae88facdc6ad1b716820cc5f678a6c4"
+      "url": "https://chromedriver.storage.googleapis.com/2.20/chromedriver_mac32.zip",
+      "checksum": "749d4be0a317e92fd3aecaa022385439"
     }
   },
   {
@@ -43,8 +43,8 @@
     "name": "iedriver",
     "roles": [ "node", "standalone" ],
     "windows": {
-      "url": "http://selenium-release.storage.googleapis.com/2.47/IEDriverServer_Win32_2.47.0.zip",
-      "checksum": "8d737f709699cc194af303660e47dfc4"
+      "url": "http://selenium-release.storage.googleapis.com/2.48/IEDriverServer_Win32_2.48.0.zip",
+      "checksum": "f7b8b07393e31d05ab360a06f51b482a"
     }
   },
   {

--- a/server/src/test/java/com/paypal/selion/grid/servlets/transfer/DownloadResponderTest.java
+++ b/server/src/test/java/com/paypal/selion/grid/servlets/transfer/DownloadResponderTest.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.util.Arrays;
 
 import javax.servlet.ServletOutputStream;
+import javax.servlet.WriteListener;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
@@ -55,6 +56,15 @@ public class DownloadResponderTest extends PowerMockTestCase {
             @Override
             public void write(int b) throws IOException {
                 bos.write(b);
+            }
+
+            @Override
+            public boolean isReady() {
+                return true;
+            }
+
+            @Override
+            public void setWriteListener(WriteListener writeListener) {
             }
         });
 


### PR DESCRIPTION
- Upgrade Selenium to version 2.48.2
- Upgrade chromedriver to version 2.20
- Upgrade IEDriverServer to version 2.48
- Fix dependencies conflicts of servlet-api jar files
- Fix testcase compilation issue on DownloadResponderTest
- Fix package of LocalGridManagerTest class in Local-Grid-Tests suite
